### PR TITLE
chore: update release-please action reference

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Release Please
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
-          changelog-notes-type: github


### PR DESCRIPTION
- Changed the action reference in the release-please workflow from `google-github-actions/release-please-action@v4` to `googleapis/release-please-action@v4` for improved consistency and accuracy in the workflow configuration.