### PR TITLE
chore: update release-please workflow to skip labeling

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,3 +18,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
+          skip-labeling: true


### PR DESCRIPTION
- Added `skip-labeling: true` to the release-please workflow configuration to streamline the release process by preventing automatic labeling of releases.