### PR TITLE
chore: update release-please workflow permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -18,4 +19,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
-          skip-labeling: true


### PR DESCRIPTION
- Added `issues: write` permission to the release-please workflow to enable issue management capabilities.
- Removed `skip-labeling: true` from the configuration to restore automatic labeling of releases.